### PR TITLE
Missing lang strings (according to Mdl2.2.2+)

### DIFF
--- a/lang/de/realtimequiz.php
+++ b/lang/de/realtimequiz.php
@@ -1,7 +1,8 @@
-<?php 
+<?php
 //Translation: Joachim Vogelgesang
 
 $string['modulename'] = 'Echtzeit Test';
+$string['pluginname'] = 'Echtzeit Test';
 $string['modulenameplural'] = 'Echtzeit Tests';
 $string['editquestions'] = 'Fragen bearbeiten';
 $string['seeresponses'] = 'Antworten sehen';
@@ -13,7 +14,7 @@ $string['sessions'] = 'Sitzungen';
 $string['submissions'] = 'Einreichungen';
 
 // Capabilities
-$string['realtimequiz:control'] = 'Start / Test Kontrolle'; 
+$string['realtimequiz:control'] = 'Start / Test Kontrolle';
 $string['realtimequiz:attempt'] = 'Test versuchen';
 $string['realtimequiz:seeresponses'] = 'Testantworten sehen';
 $string['realtimequiz:editquestions'] = 'Fragen für einen Test bearbeiten';

--- a/lang/en/realtimequiz.php
+++ b/lang/en/realtimequiz.php
@@ -52,6 +52,7 @@ $string['notallowedattempt'] = 'You are not allowed to attempt this quiz';
 $string['notauthorised'] = 'You are not authorised to control this quiz';
 $string['onecorrect'] = 'Error: There must be exactly one correct answer';
 $string['pluginadministration'] = 'Realtime quiz administration';
+$string['pluginname'] = 'Realtime quiz';
 $string['prevquestion'] = 'Previous question';
 $string['questionimage'] = '(Optional) image: ';
 $string['question'] = 'Question ';


### PR DESCRIPTION
Moodle was complaining about a missing language string 'pluginname' so I added one to both en and de lang files. 

Note that the German translation is a copy of the 'modulename' string and _assumed_ to be correct.
