### PR TITLE
Replace deprecated function calls with correct equivelent

### DIFF
--- a/lang/en/realtimequiz.php
+++ b/lang/en/realtimequiz.php
@@ -39,6 +39,7 @@ $string['httperror'] = 'There was a problem with the request - status: ';
 $string['httprequestfail'] = 'Giving up :( Cannot create an XMLHTTP instance';
 $string['incorrectstatus'] = 'Quiz has incorrect status: \'';
 $string['invalidanswer'] = 'Invalid answer number ';
+$string['invalidrealtimequizid'] = 'Realtime quiz ID was incorrect';
 $string['joininstruct'] = 'Wait until your teacher tells you before you click on this';
 $string['joinquiz'] = 'Join Quiz';
 $string['modulename'] = 'Realtime quiz';

--- a/quizdata.php
+++ b/quizdata.php
@@ -15,7 +15,7 @@ require_once($CFG->libdir.'/filelib.php');
 
 require_login();
 if (!confirm_sesskey()) {
-    error(get_string('badsesskey','realtimequiz'));
+    print_error(get_string('badsesskey', 'realtimequiz'));
 }
 $requesttype = required_param('requesttype', PARAM_ALPHA);
 $quizid = required_param('quizid', PARAM_INT);

--- a/view.php
+++ b/view.php
@@ -14,26 +14,26 @@ $a  = optional_param('a', 0, PARAM_INT);  // realtimequiz ID
 
 if ($id) {
     if (! $cm = $DB->get_record("course_modules", array('id' => $id))) {
-        error("Course Module ID was incorrect");
+        print_error('invalidcoursemodule');
     }
 
     if (! $course = $DB->get_record("course", array('id' => $cm->course))) {
-        error("Course is misconfigured");
+        print_error('coursemisconf');
     }
 
     if (! $realtimequiz = $DB->get_record("realtimequiz", array('id' => $cm->instance))) {
-        error("Course module is incorrect");
+        print_error('invalidrealtimequizid', 'realtimequiz');
     }
 
 } else {
     if (! $realtimequiz = $DB->get_record("realtimequiz", array('id' => $a))) {
-        error("Course module is incorrect");
+        print_error('invalidrealtimequizid', 'realtimequiz');
     }
     if (! $course = $DB->get_record("course", array('id' => $realtimequiz->course))) {
-        error("Course is misconfigured");
+        print_error('invalidcourseid');
     }
     if (! $cm = get_coursemodule_from_instance("realtimequiz", $realtimequiz->id, $course->id)) {
-        error("Course Module ID was incorrect");
+        print_error('missingparameter');
     }
 }
 


### PR DESCRIPTION
error is deprecated and emits warnings in developer mode, print_error should be used in its place. Also switched them to use the relevant core strings.
