### PR TITLE
fix unscaped string breaking spanish translation

### DIFF
--- a/view.php
+++ b/view.php
@@ -139,7 +139,7 @@ echo $OUTPUT->box_start('generalbox boxwidthwide boxaligncenter realtimequizbox'
         realtimequiz_set_text('joinquiz', "<?php print_string('joinquiz', 'realtimequiz') ?>");
         realtimequiz_set_text('joininstruct', "<?php print_string('joininstruct', 'realtimequiz') ?>");
         realtimequiz_set_text('waitstudent', "<?php print_string('waitstudent', 'realtimequiz') ?>");
-        realtimequiz_set_text('clicknext', "<?php print_string('clicknext', 'realtimequiz') ?>");
+        realtimequiz_set_text('clicknext', "<?php addslashes(get_string('clicknext', 'realtimequiz')) ?>");
         realtimequiz_set_text('waitfirst', "<?php print_string('waitfirst', 'realtimequiz') ?>");
         realtimequiz_set_text('question', "<?php print_string('question', 'realtimequiz') ?>");
         realtimequiz_set_text('invalidanswer', "<?php print_string('invalidanswer', 'realtimequiz') ?>");


### PR DESCRIPTION
The spanish translation has double quotation marks in the 'clicknext' lang string. Since the string is simply printed into the Javascript unscaped, this breaks the javascript.

![The error](https://github.com/davosmith/moodle-realtimequiz/assets/12688373/ab98615a-d07d-402f-b4d6-1bfd2e7ec0e1)

![The broken javascript](https://github.com/davosmith/moodle-realtimequiz/assets/12688373/9a6ab06b-7343-4c34-824c-4a884c36a2e0)

This commit simply scapes the specific print_string. For consistency and to prevent this happening to another language, it might be better to apply the same solution to all strings.

Fixing this here might be unnecesary, as I also sent a PR to AMOS to change the double quotation marks with single quotation marks and/or to scape them in the translation correctly in the first place.